### PR TITLE
fix: on page refresh isLoggedIn and isRefresh became false in Private…

### DIFF
--- a/src/redux-store/slices/authSlice.js
+++ b/src/redux-store/slices/authSlice.js
@@ -5,7 +5,7 @@ import
   logIn,
   logOut,
   sendDataCountryToBackend,
-} from '../AuthOperations/AuthOperations.js';
+} from '@/redux-store/AuthOperations/AuthOperations';
 
 const initialState = {
   token: null,
@@ -15,7 +15,8 @@ const initialState = {
   flagCode: null,
 };
 
-const handlePending = () => ({
+const handlePending = (state) => ({
+  ...state,
   isRefresh: true,
 });
 
@@ -56,13 +57,10 @@ export const authSlice = createSlice({
       }))
 
       .addCase(sendDataCountryToBackend.pending, handlePending)
-      .addCase(sendDataCountryToBackend.rejected, (state, action) =>
-      {
-        handleRejected(state, action);
-      })
+      .addCase(sendDataCountryToBackend.rejected, handleRejected)
       .addCase(sendDataCountryToBackend.fulfilled, (state, action) => ({
-        ...state,
-        name: action.payload.name,
+        // ...state,
+        // name: action.payload.name,
         flagCode: action.payload.flagCode,
       })),
 });

--- a/src/redux-store/store.js
+++ b/src/redux-store/store.js
@@ -1,14 +1,15 @@
 import { configureStore, combineSlices } from '@reduxjs/toolkit';
-import {
-  persistStore,
-  persistReducer,
-  FLUSH,
-  REHYDRATE,
-  PAUSE,
-  PERSIST,
-  PURGE,
-  REGISTER,
-} from 'redux-persist';
+import
+  {
+    persistStore,
+    persistReducer,
+    FLUSH,
+    REHYDRATE,
+    PAUSE,
+    PERSIST,
+    PURGE,
+    REGISTER,
+  } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import { authSlice } from './slices/authSlice';
 import { userSlice } from './slices/userSlice';
@@ -16,7 +17,7 @@ import { userSlice } from './slices/userSlice';
 const authPersistConfig = {
   key: 'auth',
   storage,
-  whitelist: ['token'],
+  whitelist: ['token', 'isLoggedIn'],
 };
 
 const rootPersistConfig = {


### PR DESCRIPTION
Regina found that on page refresh isLoggedIn and isRefresh became false in PrivateRoute check and redirect to LOGIN page was initiated.
In previous commits I have changed initial state of isRefresh in authSlice from TRUE to FALSE assuming that it should be true only when changed function in authSlice.js:

const handlePending = (state) => ({
  ...state,
  isRefresh: true,
});

but that lead to both  isLoggedIn and isRefresh set to FALSE when page was reloaded.

Also when PrivateRoute initiates redirect, it redirects to LOGIN page which is set by routesConfig.js logic for all components wrapped by <PrivateRoute/> and in PrivateRoute.js redirect is set to MAIN.
